### PR TITLE
fix: Ensure consistent handling of publication timestamps

### DIFF
--- a/core/admin/handler_content.go
+++ b/core/admin/handler_content.go
@@ -243,6 +243,7 @@ func (h *Handler) ContentCreate(c *gin.Context) {
 			item.PublishedAt = &now
 		}
 	}
+	ensurePublishedAtForPublished(item)
 
 	filterQuery := listFilterQuery(c)
 	if err := h.svc.CreateContent(item); err != nil {
@@ -284,6 +285,14 @@ func (h *Handler) ContentCreate(c *gin.Context) {
 	h.invalidatePageCache()
 	h.logAction(c, "create", typeName, item.ID, item.Title)
 	c.Redirect(http.StatusFound, listRedirectURL(slug, filterQuery, "success", adminT(lang, "notice.created")))
+}
+
+func ensurePublishedAtForPublished(item *content.Content) {
+	if item == nil || item.Status != content.StatusPublished || item.PublishedAt != nil {
+		return
+	}
+	now := time.Now()
+	item.PublishedAt = &now
 }
 
 // ==================== Content Edit ====================
@@ -398,6 +407,7 @@ func (h *Handler) ContentUpdate(c *gin.Context) {
 			item.PublishedAt = nil
 		}
 	}
+	ensurePublishedAtForPublished(item)
 
 	if err := h.svc.UpdateContent(item); err != nil {
 		view := h.svc.ToDynamicContentView(*item, typeDef)

--- a/core/admin/handler_content_test.go
+++ b/core/admin/handler_content_test.go
@@ -1,0 +1,39 @@
+package admin
+
+import (
+	"testing"
+
+	"go-press/core/content"
+)
+
+func TestEnsurePublishedAtForPublishedSetsMissingTime(t *testing.T) {
+	item := &content.Content{Status: content.StatusPublished}
+
+	ensurePublishedAtForPublished(item)
+
+	if item.PublishedAt == nil {
+		t.Fatal("PublishedAt should be set for published content")
+	}
+}
+
+func TestEnsurePublishedAtForPublishedPreservesExistingTime(t *testing.T) {
+	item := &content.Content{Status: content.StatusPublished}
+	ensurePublishedAtForPublished(item)
+	first := item.PublishedAt
+
+	ensurePublishedAtForPublished(item)
+
+	if item.PublishedAt != first {
+		t.Fatal("PublishedAt should not be replaced when already set")
+	}
+}
+
+func TestEnsurePublishedAtForPublishedLeavesDraftUnset(t *testing.T) {
+	item := &content.Content{Status: content.StatusDraft}
+
+	ensurePublishedAtForPublished(item)
+
+	if item.PublishedAt != nil {
+		t.Fatal("PublishedAt should remain nil for draft content")
+	}
+}

--- a/core/content/query.go
+++ b/core/content/query.go
@@ -64,12 +64,13 @@ func (q *ContentQuery) Status(s string) *ContentQuery {
 
 // Published limits results to rows visible on the public site.
 //
-// A row must have StatusPublished and a non-null PublishedAt that is not in the
-// future. This prevents scheduled posts from appearing before their publish
-// time while still keeping them editable in admin.
+// A row must have StatusPublished and either no explicit publish time or a
+// PublishedAt that is not in the future. NULL PublishedAt is treated as
+// immediately published for custom content types that do not expose a
+// publish_date field, while future timestamps still support scheduled content.
 func (q *ContentQuery) Published() *ContentQuery {
 	tbl := dbprefix.Table("contents")
-	q.db = q.db.Where(tbl+".status = ? AND "+tbl+".published_at IS NOT NULL AND "+tbl+".published_at <= NOW()", StatusPublished)
+	q.db = q.db.Where(tbl+".status = ? AND ("+tbl+".published_at IS NULL OR "+tbl+".published_at <= NOW())", StatusPublished)
 	return q
 }
 

--- a/core/theme/base.go
+++ b/core/theme/base.go
@@ -409,7 +409,7 @@ func (b *BaseTheme) renderArchive(c *gin.Context, route *rewrite.ResolvedRoute) 
 
 	result, err := content.NewQuery(content.ScopedDB(c, b.App.Database())).
 		Type(route.ContentType).Published().
-		OrderBy("published_at", "DESC").
+		OrderBy(archiveOrderField(typeDef), archiveOrderDir(typeDef)).
 		Paginate(page, perPage)
 	if err != nil {
 		logger.Error("BaseTheme: archive query failed", "type", route.ContentType, "error", err)
@@ -704,6 +704,32 @@ func singlePageCandidates(contentType, slug string, typeDef *content.ContentType
 	}
 	candidates = append(candidates, "single")
 	return uniqueStrings(candidates)
+}
+
+func archiveOrderField(typeDef *content.ContentTypeDef) string {
+	if contentTypeSupports(typeDef, "sort_order") {
+		return "sort_order"
+	}
+	return "published_at"
+}
+
+func archiveOrderDir(typeDef *content.ContentTypeDef) string {
+	if contentTypeSupports(typeDef, "sort_order") {
+		return "ASC"
+	}
+	return "DESC"
+}
+
+func contentTypeSupports(typeDef *content.ContentTypeDef, feature string) bool {
+	if typeDef == nil {
+		return false
+	}
+	for _, support := range typeDef.Supports {
+		if support == feature {
+			return true
+		}
+	}
+	return false
 }
 
 func uniqueStrings(in []string) []string {

--- a/core/theme/dynamic_test.go
+++ b/core/theme/dynamic_test.go
@@ -93,6 +93,28 @@ func TestLegacyAliasesPointToCurrentArchiveOnly(t *testing.T) {
 	}
 }
 
+func TestArchiveOrderUsesSortOrderWhenSupported(t *testing.T) {
+	typeDef := &content.ContentTypeDef{Supports: []string{"title", "sort_order"}}
+
+	if got := archiveOrderField(typeDef); got != "sort_order" {
+		t.Fatalf("archiveOrderField = %q, want sort_order", got)
+	}
+	if got := archiveOrderDir(typeDef); got != "ASC" {
+		t.Fatalf("archiveOrderDir = %q, want ASC", got)
+	}
+}
+
+func TestArchiveOrderDefaultsToPublishedAt(t *testing.T) {
+	typeDef := &content.ContentTypeDef{Supports: []string{"title"}}
+
+	if got := archiveOrderField(typeDef); got != "published_at" {
+		t.Fatalf("archiveOrderField = %q, want published_at", got)
+	}
+	if got := archiveOrderDir(typeDef); got != "DESC" {
+		t.Fatalf("archiveOrderDir = %q, want DESC", got)
+	}
+}
+
 func containsString(items []string, want string) bool {
 	for _, item := range items {
 		if item == want {


### PR DESCRIPTION
Adds a utility function to automatically set the publication timestamp for published content without one. Updates the query logic to treat null publication timestamps as immediately published for certain content types. Enhances archive ordering to support custom sort fields and adds related unit tests.

These changes improve content handling flexibility, support for custom content types, and ensure proper ordering in archives.