### PR TITLE
refactor: Add `pageTitleFor` helper and improve SEO integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ go run ./cmd/gendoc/
 ### Themes and Plugins
 
 - **BaseTheme runtime** — embed it to get config-driven URL resolution, dynamic archive/detail rendering, WordPress-style fallback hierarchy, and automatic SEO integration.
-- **Unified FuncMap** — `BaseFuncMap()` provides `buildURL`, `archiveURL`, `contentURL`, `seoHeadFor`, `menuByLocation`, `T`, `currentLang`, `langPrefixURL`, `renderHook`, and `responsiveImage*`.
+- **Unified FuncMap** — `BaseFuncMap()` provides `buildURL`, `archiveURL`, `contentURL`, `pageTitleFor`, `seoHeadFor`, `menuByLocation`, `T`, `currentLang`, `langPrefixURL`, `renderHook`, and `responsiveImage*`.
 - **Theme template slots** — `theme.head.end`, `theme.body.open`, `theme.footer.end`, and `header.nav.after` define semantic insertion points for plugins.
 - **Responsive image pipeline** — uploads generate WebP and JPG/PNG variants (`thumb`, `480w`, `768w`, `1024w`, `1440w`, `full`), and templates output `<picture>` through `responsiveImage`.
 - **Hot-pluggable plugins** — `Bus.AddAction/AddFilter` return handles; `Deactivate` removes hooks cleanly without restarting the process.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -213,7 +213,7 @@ API 接口规范单独存放，由 `swag` 从代码注解自动生成：
 ### 主题与插件
 
 - **BaseTheme 运行时引擎** — 嵌入即获得配置驱动 URL 解析、动态归档/详情渲染、模板层级回退（WordPress 风格）和 SEO 自动注入
-- **统一 FuncMap** — `BaseFuncMap()` 单一来源下发：`buildURL` / `archiveURL` / `contentURL` / `seoHeadFor` / `menuByLocation` / `T` / `currentLang` / `langPrefixURL` / `renderHook` / `responsiveImage*`
+- **统一 FuncMap** — `BaseFuncMap()` 单一来源下发：`buildURL` / `archiveURL` / `contentURL` / `pageTitleFor` / `seoHeadFor` / `menuByLocation` / `T` / `currentLang` / `langPrefixURL` / `renderHook` / `responsiveImage*`
 - **主题模板插槽** — `theme.head.end` / `theme.body.open` / `theme.footer.end` / `header.nav.after` 组成前台插件接入契约，主题只声明语义位置，插件按需输出 HTML
 - **响应式图片管线** — 上传时生成 WebP + JPG/PNG 变体（thumb/480w/768w/1024w/1440w/full），模板用 `responsiveImage` 输出 `<picture>`
 - **插件热拔插** — `Bus.AddAction/AddFilter` 返回 `Handle`，`Deactivate` 中 `Remove*` 干净下线，运行时即时切换无需重启

--- a/core/admin/handler.go
+++ b/core/admin/handler.go
@@ -708,6 +708,7 @@ func (h *Handler) render(c *gin.Context, name string, data gin.H) {
 
 	adminLang := h.svc.AdminLanguage()
 	data["AdminLanguage"] = adminLang
+	data["Ctx"] = c
 	data["CurrentRole"] = c.GetString("admin_role")
 	data["CurrentUser"] = c.GetString("admin_username")
 	data["MenuItems"] = h.buildMenuItems(adminLang)

--- a/core/admin/handler_content.go
+++ b/core/admin/handler_content.go
@@ -179,6 +179,7 @@ func (h *Handler) ContentNew(c *gin.Context) {
 		"TypeDef":   typeDef,
 		"TypeName":  typeName,
 		"Slug":      slug,
+		"HookItem":  (*content.Content)(nil),
 		"BackURL":   listURLWithFilter(slug, filterQuery),
 		"BackQuery": filterQuery,
 	}
@@ -253,6 +254,7 @@ func (h *Handler) ContentCreate(c *gin.Context) {
 			"TypeDef": typeDef, "TypeName": typeName, "Slug": slug,
 			"Item":      view,
 			"Error":     adminT(lang, "error.create_failed", err.Error()),
+			"HookItem":  item,
 			"BackURL":   listURLWithFilter(slug, filterQuery),
 			"BackQuery": filterQuery,
 		}
@@ -339,6 +341,7 @@ func (h *Handler) ContentEdit(c *gin.Context) {
 		"Slug":            slug,
 		"Item":            view,
 		"PermalinkPrefix": permalinkPrefix,
+		"HookItem":        item,
 		"BackURL":         listURLWithFilter(slug, filterQuery),
 		"BackQuery":       filterQuery,
 	}
@@ -416,6 +419,7 @@ func (h *Handler) ContentUpdate(c *gin.Context) {
 			"TypeDef": typeDef, "TypeName": typeName, "Slug": slug,
 			"Item":      view,
 			"Error":     adminT(lang, "error.update_failed", err.Error()),
+			"HookItem":  item,
 			"BackURL":   listURLWithFilter(slug, filterQuery),
 			"BackQuery": filterQuery,
 		}

--- a/core/admin/handler_content_test.go
+++ b/core/admin/handler_content_test.go
@@ -1,9 +1,18 @@
 package admin
 
 import (
+	"bytes"
+	"html/template"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
+
 	"go-press/core/content"
+	"go-press/core/hook"
+	"go-press/core/user"
 )
 
 func TestEnsurePublishedAtForPublishedSetsMissingTime(t *testing.T) {
@@ -35,5 +44,61 @@ func TestEnsurePublishedAtForPublishedLeavesDraftUnset(t *testing.T) {
 
 	if item.PublishedAt != nil {
 		t.Fatal("PublishedAt should remain nil for draft content")
+	}
+}
+
+func TestContentFormHookReceivesStableCoreArgs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, ctx := gin.CreateTestContext(httptest.NewRecorder())
+
+	h := NewHandler(
+		&Service{rbac: user.NewRBAC()},
+		content.NewRegistry(),
+		filepath.Join("templates"),
+	)
+
+	var captured []interface{}
+	bus := hook.New()
+	bus.AddFilter(hook.AdminContentFormFields, func(value interface{}, args ...interface{}) interface{} {
+		captured = append([]interface{}{}, args...)
+		return template.HTML(`<div id="hook-output"></div>`)
+	}, 10)
+	h.SetHookBus(bus)
+
+	tmpl, err := template.New("content_form_test").Funcs(h.funcMap).ParseFiles(filepath.Join("templates", "pages", "content_form.tmpl"))
+	if err != nil {
+		t.Fatalf("parse content form template: %v", err)
+	}
+
+	typeDef := &content.ContentTypeDef{
+		Name:     "post",
+		Label:    "Post",
+		Supports: []string{"title"},
+		Rewrite:  content.RewriteRule{Slug: "blog"},
+	}
+	item := &content.Content{ID: 42, Type: "post", Title: "SEO Post", Slug: "seo-post"}
+	view := DynamicContentView{ID: item.ID, Title: item.Title, Slug: item.Slug}
+	data := gin.H{
+		"Ctx":           ctx,
+		"Title":         "Edit Post",
+		"TypeDef":       typeDef,
+		"TypeName":      "post",
+		"Slug":          "posts",
+		"Item":          view,
+		"HookItem":      item,
+		"BackURL":       "/admin/posts",
+		"BackQuery":     "",
+		"AdminLanguage": defaultAdminLanguage,
+	}
+
+	var out bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&out, "content", data); err != nil {
+		t.Fatalf("execute content form template: %v", err)
+	}
+	if !strings.Contains(out.String(), `id="hook-output"`) {
+		t.Fatal("expected hook output to render")
+	}
+	if len(captured) != 3 || captured[0] != ctx || captured[1] != item || captured[2] != typeDef {
+		t.Fatalf("unexpected hook args: %#v", captured)
 	}
 }

--- a/core/admin/templates/pages/content_form.tmpl
+++ b/core/admin/templates/pages/content_form.tmpl
@@ -105,7 +105,7 @@
         {{end}}
 
         {{/* Plugin extension slot — meta boxes contributed by plugins (e.g. seo-extras). */}}
-        {{renderHook "admin.content_form.fields" .Item .TypeDef}}
+        {{renderHook "admin.content_form.fields" .Ctx .HookItem .TypeDef}}
 
         {{range $tf := .TaxForms}}
         <div class="form-group">

--- a/core/theme/funcmap.go
+++ b/core/theme/funcmap.go
@@ -112,6 +112,12 @@ func CommonFuncMap() template.FuncMap {
 		"seoHeadFor": func(data interface{}) template.HTML {
 			return ""
 		},
+		"pageTitleFor": func(data interface{}, fallback string) string {
+			if title := pageTitleFromData(data); title != "" {
+				return title
+			}
+			return fallback
+		},
 		"menuByLocation": func(location string) *menu.Menu {
 			return nil
 		},
@@ -166,6 +172,60 @@ func CommonFuncMap() template.FuncMap {
 			return seg == activePage
 		},
 	}
+}
+
+func pageTitleFromData(data interface{}) string {
+	if data == nil {
+		return ""
+	}
+	v := reflect.ValueOf(data)
+	v = unwrapTemplateValue(v)
+	if !v.IsValid() {
+		return ""
+	}
+
+	var meta reflect.Value
+	switch v.Kind() {
+	case reflect.Map:
+		meta = v.MapIndex(reflect.ValueOf("SEO"))
+	case reflect.Struct:
+		meta = v.FieldByName("SEO")
+	default:
+		return ""
+	}
+	return titleFromMetaValue(meta)
+}
+
+func titleFromMetaValue(v reflect.Value) string {
+	v = unwrapTemplateValue(v)
+	if !v.IsValid() {
+		return ""
+	}
+
+	var title reflect.Value
+	switch v.Kind() {
+	case reflect.Map:
+		title = v.MapIndex(reflect.ValueOf("Title"))
+	case reflect.Struct:
+		title = v.FieldByName("Title")
+	default:
+		return ""
+	}
+	title = unwrapTemplateValue(title)
+	if !title.IsValid() || title.Kind() != reflect.String {
+		return ""
+	}
+	return strings.TrimSpace(title.String())
+}
+
+func unwrapTemplateValue(v reflect.Value) reflect.Value {
+	for v.IsValid() && (v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr) {
+		if v.IsNil() {
+			return reflect.Value{}
+		}
+		v = v.Elem()
+	}
+	return v
 }
 
 func stringField(item interface{}, name string) string {

--- a/core/theme/funcmap_test.go
+++ b/core/theme/funcmap_test.go
@@ -1,0 +1,30 @@
+package theme
+
+import "testing"
+
+func TestPageTitleForUsesSEOTitleFromStruct(t *testing.T) {
+	type meta struct{ Title string }
+	type page struct{ SEO meta }
+
+	fn := CommonFuncMap()["pageTitleFor"].(func(interface{}, string) string)
+	if got := fn(page{SEO: meta{Title: " Custom Title "}}, "Fallback Title"); got != "Custom Title" {
+		t.Fatalf("pageTitleFor() = %q, want Custom Title", got)
+	}
+}
+
+func TestPageTitleForUsesSEOTitleFromMap(t *testing.T) {
+	fn := CommonFuncMap()["pageTitleFor"].(func(interface{}, string) string)
+	data := map[string]interface{}{"SEO": map[string]interface{}{"Title": "Mapped Title"}}
+
+	if got := fn(data, "Fallback Title"); got != "Mapped Title" {
+		t.Fatalf("pageTitleFor() = %q, want Mapped Title", got)
+	}
+}
+
+func TestPageTitleForFallsBackWhenNoTitle(t *testing.T) {
+	fn := CommonFuncMap()["pageTitleFor"].(func(interface{}, string) string)
+
+	if got := fn(struct{}{}, "Fallback Title"); got != "Fallback Title" {
+		t.Fatalf("pageTitleFor() = %q, want Fallback Title", got)
+	}
+}

--- a/docs/guide/en/themes/creating-themes.md
+++ b/docs/guide/en/themes/creating-themes.md
@@ -159,7 +159,7 @@ Every plugin-friendly theme should declare:
 {{renderHook "header.nav.after" .}}
 ```
 
-Use `seoHeadFor`, `settingOr`, `archiveURL`, `contentURL`, `currentLang`, `langPrefixURL`, `menuByLocation`, and the responsive image helpers from the core funcmap instead of implementing theme-local equivalents.
+Use `pageTitleFor`, `seoHeadFor`, `settingOr`, `archiveURL`, `contentURL`, `currentLang`, `langPrefixURL`, `menuByLocation`, and the responsive image helpers from the core funcmap instead of implementing theme-local equivalents.
 
 ## Demo Data
 

--- a/docs/guide/en/themes/seo-integration.md
+++ b/docs/guide/en/themes/seo-integration.md
@@ -10,19 +10,20 @@ System Settings
   -> ApplySiteOptionOverrides
   -> optional seo.content.meta filters
   -> data["SEO"] or PageData.SEO
-  -> {{seoHeadFor .}}
-  -> HTML head, including favicon links when site_icon is set
+  -> {{pageTitleFor . $fallbackTitle}} and {{seoHeadFor .}}
+  -> HTML head, including <title> and favicon links when site_icon is set
 ```
 
 ## Required Contracts
 
-### Use `site_name` for titles
+### Use `pageTitleFor` for document titles
 
-```html
-<title>{{.Title}} - {{settingOr .Settings "site_name" "My Theme"}}</title>
+```gotemplate
+{{$fallbackTitle := printf "%s - %s" .Title (settingOr .Settings "site_name" "My Theme")}}
+<title>{{pageTitleFor . $fallbackTitle}}</title>
 ```
 
-Do not hard-code the brand name in `<title>`, and do not use theme-local keys such as `company_name` for SEO titles.
+`pageTitleFor` is a core page-metadata helper, not a plugin dependency. It returns the current page title from core metadata when available, including values changed by optional filters, and otherwise returns the theme fallback. Do not hard-code the brand name in `<title>`, and do not use theme-local keys such as `company_name` for document titles.
 
 ### Use `seoHeadFor`
 

--- a/docs/guide/zh-CN/themes/creating-themes.md
+++ b/docs/guide/zh-CN/themes/creating-themes.md
@@ -185,7 +185,8 @@ archive
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{.Title}} - {{settingOr .Settings "site_name" "My Theme"}}</title>
+    {{$fallbackTitle := printf "%s - %s" .Title (settingOr .Settings "site_name" "My Theme")}}
+    <title>{{pageTitleFor . $fallbackTitle}}</title>
     {{with seoHeadFor .}}{{.}}{{else}}<meta name="description" content="{{settingOr $.Settings "site_description" "My theme default description."}}">{{end}}
     <link rel="stylesheet" href="/static/css/style.css">
     {{renderHook "theme.head.end" .}}

--- a/docs/guide/zh-CN/themes/overview.md
+++ b/docs/guide/zh-CN/themes/overview.md
@@ -12,7 +12,7 @@ GoPress 的主题系统借鉴 WordPress 设计：主题是一个 Go 包，通过
 - **Theme 接口** — 实现 `Name()` / `Setup()` / `ServeHTTP()` / `TemplateFuncs()` 即可
 - **App 接口** — 主题通过 `theme.App` 接口访问 DB、ContentRepo、RewriteEngine、SEOBuilder、MediaRepo、HookBus 等引擎能力
 - **模板层级回退** — 类 WordPress 的模板查找：`single-{type}-{slug}.tmpl` → `single-{type}.tmpl` → `single.tmpl` → `index.tmpl`
-- **统一模板函数（Single-Source FuncMap）** — `CommonFuncMap()` + BaseTheme 的引擎感知 helpers（`buildURL`、`archiveURL`、`contentURL`、`seoHead`、`menuByLocation`、`T`、`currentLang`、`langPrefixURL`、`renderHook`、`isMenuActive`、`responsiveImage`、`responsiveImagePriority`、`responsiveImagePreload`）通过 `BaseFuncMap()` 统一下发。**所有主题、所有模板加载路径共享同一份 funcmap**
+- **统一模板函数（Single-Source FuncMap）** — `CommonFuncMap()` + BaseTheme 的引擎感知 helpers（`buildURL`、`archiveURL`、`contentURL`、`pageTitleFor`、`seoHeadFor`、`seoHead`、`menuByLocation`、`T`、`currentLang`、`langPrefixURL`、`renderHook`、`isMenuActive`、`responsiveImage`、`responsiveImagePriority`、`responsiveImagePreload`）通过 `BaseFuncMap()` 统一下发。**所有主题、所有模板加载路径共享同一份 funcmap**
 - **前台模板 Hook 插槽** — 主题在语义位置声明 `{{renderHook "theme.head.end" .}}` / `{{renderHook "theme.body.open" .}}` / `{{renderHook "theme.footer.end" .}}` / `{{renderHook "header.nav.after" .}}` 等标准插槽，插件注册同名 filter 输出 HTML
 - **LoadPageBundle 核心级页面模板编译器** — `core/theme/page_bundle.go` 提供 `LoadPageBundle(theme, pages)` 和 `LoadAllPageBundles(theme)`：自动发现 `layouts/base.tmpl` + `partials/*.tmpl` + `pages/*.tmpl`，对每个页面独立编译（允许不同页面重新定义同名 block）
 - **自定义路由 + 动态路由** — 静态页面（`/about`）通过 `AddRoute()` 注册，动态 URL（例如主题声明的 `product` 对应 `/products/:slug`）由 Rewrite 引擎按当前内容类型配置自动解析；`product` / `service` / `showcase` 只是常见示例，不是 core 固定模型
@@ -127,6 +127,6 @@ e.Hooks.RemoveFilter(handle)
 ## 下一步
 
 - [创建主题](creating-themes.md) — 完整 step-by-step 教程
-- [SEO 接入规范](seo-integration.md) — `<title>` / `<meta description>` / `seoHeadFor` 契约
+- [SEO 接入规范](seo-integration.md) — `<title>` / `<meta description>` / `pageTitleFor` / `seoHeadFor` 契约
 - [图片接入规范](image-pipeline.md) — `responsiveImage` 等 helper 用法
 - [媒体变体管线](media-variants.md) — 上传后自动生成的 thumb / 480w / WebP 等变体

--- a/docs/guide/zh-CN/themes/seo-integration.md
+++ b/docs/guide/zh-CN/themes/seo-integration.md
@@ -25,20 +25,21 @@ core ApplySiteOptionOverrides
 data["SEO"] = SEOMeta{...}            （BaseTheme 路径自动注入）
 data.PageData.SEO = SEOMeta{...}      （自定义 struct 主题手动注入）
                            ▼
-template: {{with seoHeadFor .}}{{.}}{{else}}<meta description fallback>{{end}}
+template: {{pageTitleFor . $fallbackTitle}} + {{with seoHeadFor .}}{{.}}{{else}}<meta description fallback>{{end}}
                            ▼
-HTML <head>: <meta description> + <link canonical> + og:* + JSON-LD + favicon links
+HTML <head>: <title> + <meta description> + <link canonical> + og:* + JSON-LD + favicon links
 ```
 
 ## 必须遵守的三条契约
 
-### 1. `<title>` 拼接走 `site_name`
+### 1. `<title>` 走 `pageTitleFor` + 主题 fallback
 
-不要硬编码品牌字、不要发明 `company_name` 之类的本地 key：
+`pageTitleFor` 是 core 的页面标题 helper，不是 SEO 插件依赖。它会优先使用 core 注入的页面 metadata 标题；如果没有，就返回主题传入的 fallback。因此插件禁用时页面标题仍然正常。不要硬编码品牌字、不要发明 `company_name` 之类的本地 key：
 
-```html
-<!-- ✅ 正确：core 唯一来源 + 主题兜底默认 -->
-<title>{{.Title}} - {{settingOr .Settings "site_name" "My Theme Default"}}</title>
+```gotemplate
+<!-- ✅ 正确：core 页面标题 + 主题兜底默认 -->
+{{$fallbackTitle := printf "%s - %s" .Title (settingOr .Settings "site_name" "My Theme Default")}}
+<title>{{pageTitleFor . $fallbackTitle}}</title>
 
 <!-- ❌ 错：硬编码 -->
 <title>{{.Title}} - Hurricane Techs</title>
@@ -91,7 +92,8 @@ func (t *MyTheme) ServeHTTP(c *gin.Context) {
 
 ```html
 <!-- templates/layouts/base.tmpl -->
-<title>{{.Title}} - {{settingOr .Settings "site_name" "My Theme"}}</title>
+{{$fallbackTitle := printf "%s - %s" .Title (settingOr .Settings "site_name" "My Theme")}}
+<title>{{pageTitleFor . $fallbackTitle}}</title>
 {{$siteIcon := settingOr .Settings "site_icon" ""}}
 {{with seoHeadFor .}}{{.}}{{else}}
 <meta name="description" content="{{settingOr $.Settings "site_description" "..."}}">

--- a/plugins/seo-extras/plugin.go
+++ b/plugins/seo-extras/plugin.go
@@ -106,9 +106,9 @@ func (p *Plugin) Deactivate(app plugin.App) {
 }
 
 // renderMetaBox returns the meta box HTML appended to whatever earlier
-// filters returned. Filter args are: (*content.Content, *content.ContentTypeDef).
-// On the create form .Item is nil, so we treat metaMap as empty — the form
-// renders with all blanks and saveFields handles the first persist normally.
+// filters returned. Filter args are: (*gin.Context, *content.Content,
+// *content.ContentTypeDef). On the create form the content arg is nil, so the
+// form renders with all blanks and saveFields handles the first persist normally.
 func (p *Plugin) renderMetaBox(value interface{}, args ...interface{}) interface{} {
 	if p.engine == nil || !p.engine.PluginManager.IsActive(PluginName) {
 		return value
@@ -122,16 +122,24 @@ func (p *Plugin) renderMetaBox(value interface{}, args ...interface{}) interface
 		existing = template.HTML(v)
 	}
 
-	// args[0] may be *content.Content (edit) or nil (create). Pre-fill the
-	// form with stored values when editing.
+	// The admin hook contract passes core content directly. This plugin does
+	// not inspect admin view models, so it stays independent of admin UI shape.
 	var meta map[string]string
-	if len(args) > 0 {
-		if item, ok := args[0].(*content.Content); ok && item != nil && item.ID != 0 {
-			meta, _ = p.engine.Content.GetMeta(item.ID)
-		}
+	if item := firstContentArg(args); item != nil && item.ID != 0 {
+		meta, _ = p.engine.Content.GetMeta(item.ID)
 	}
 
 	return existing + buildMetaBoxHTML(meta)
+}
+
+func firstContentArg(args []interface{}) *content.Content {
+	for _, arg := range args {
+		item, ok := arg.(*content.Content)
+		if ok {
+			return item
+		}
+	}
+	return nil
 }
 
 // saveFields writes the four SEO override fields to gp_content_meta. Empty

--- a/themes/atelier-slate/templates/layouts/base.tmpl
+++ b/themes/atelier-slate/templates/layouts/base.tmpl
@@ -3,7 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{.Title}} - {{settingOr .Settings "site_name" "Atelier Slate"}}</title>
+    {{$fallbackTitle := printf "%s - %s" .Title (settingOr .Settings "site_name" "Atelier Slate")}}
+    <title>{{pageTitleFor . $fallbackTitle}}</title>
     {{$siteIcon := settingOr .Settings "site_icon" ""}}
     {{with seoHeadFor .}}{{.}}{{else}}
     <meta name="description" content="{{settingOr $.Settings "site_description" "A strategic digital studio for launch campaigns, product storytelling, and immersive brand systems."}}">

--- a/themes/axis-form/templates/layouts/base.tmpl
+++ b/themes/axis-form/templates/layouts/base.tmpl
@@ -6,7 +6,8 @@
     {{if not $hero}}{{$hero = "https://images.unsplash.com/photo-1600585154340-be6161a56a0c?w=1800&h=980&fit=crop&q=84"}}{{end}}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{.Title}} - {{settingOr .Settings "site_name" "Axis Form"}}</title>
+    {{$fallbackTitle := printf "%s - %s" .Title (settingOr .Settings "site_name" "Axis Form")}}
+    <title>{{pageTitleFor . $fallbackTitle}}</title>
     {{$siteIcon := settingOr .Settings "site_icon" ""}}
     {{with seoHeadFor .}}{{.}}{{else}}
     <meta name="description" content="{{settingOr $.Settings "site_description" "Architecture, interiors, planning, and project management for enduring spaces."}}">

--- a/themes/civic-estate/templates/layouts/base.tmpl
+++ b/themes/civic-estate/templates/layouts/base.tmpl
@@ -6,7 +6,8 @@
     {{if not $hero}}{{$hero = "https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?w=1800&h=980&fit=crop&q=84"}}{{end}}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{.Title}} - {{settingOr .Settings "site_name" "Civic Estate"}}</title>
+    {{$fallbackTitle := printf "%s - %s" .Title (settingOr .Settings "site_name" "Civic Estate")}}
+    <title>{{pageTitleFor . $fallbackTitle}}</title>
     {{$siteIcon := settingOr .Settings "site_icon" ""}}
     {{with seoHeadFor .}}{{.}}{{else}}
     <meta name="description" content="{{settingOr $.Settings "site_description" "Commercial property search, leasing advisory, and market-ready real-estate intelligence."}}">

--- a/themes/financial-news/templates/layouts/base.tmpl
+++ b/themes/financial-news/templates/layouts/base.tmpl
@@ -3,7 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{.Title}} | {{settingOr .Settings "site_name" "FinNews"}}</title>
+    {{$fallbackTitle := printf "%s | %s" .Title (settingOr .Settings "site_name" "FinNews")}}
+    <title>{{pageTitleFor . $fallbackTitle}}</title>
     {{$siteIcon := settingOr .Settings "site_icon" ""}}
     {{with seoHeadFor .}}{{.}}{{else}}
     <meta name="description" content="{{settingOr $.Settings "site_description" "Financial news, market analysis, and investment insights."}}">

--- a/themes/florafi/templates/layouts/base.tmpl
+++ b/themes/florafi/templates/layouts/base.tmpl
@@ -3,7 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{.Title}} - {{settingOr .Settings "site_name" "FloraFi"}}</title>
+    {{$fallbackTitle := printf "%s - %s" .Title (settingOr .Settings "site_name" "FloraFi")}}
+    <title>{{pageTitleFor . $fallbackTitle}}</title>
     {{$siteIcon := settingOr .Settings "site_icon" ""}}
     {{with seoHeadFor .}}{{.}}{{else}}
     <meta name="description" content="{{settingOr $.Settings "site_description" "A progressive stablecoin ecosystem designed to move value and power real economies."}}">

--- a/themes/go-press-landing/templates/layouts/base.tmpl
+++ b/themes/go-press-landing/templates/layouts/base.tmpl
@@ -3,7 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{.Title}} - {{settingOr .Settings "site_name" "GoPress"}}</title>
+    {{$fallbackTitle := printf "%s - %s" .Title (settingOr .Settings "site_name" "GoPress")}}
+    <title>{{pageTitleFor . $fallbackTitle}}</title>
     {{$siteIcon := settingOr .Settings "site_icon" ""}}
     {{with seoHeadFor .}}{{.}}{{else}}
     <meta name="description" content="{{settingOr $.Settings "site_description" "NovaPulse AI — Enterprise-grade platform for deploying, monitoring, and scaling machine learning models in production."}}">

--- a/themes/modern-company/templates/layouts/base.tmpl
+++ b/themes/modern-company/templates/layouts/base.tmpl
@@ -3,7 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{.Title}} - {{settingOr .Settings "site_name" "Modern Company"}}</title>
+    {{$fallbackTitle := printf "%s - %s" .Title (settingOr .Settings "site_name" "Modern Company")}}
+    <title>{{pageTitleFor . $fallbackTitle}}</title>
     {{$siteIcon := settingOr .Settings "site_icon" ""}}
     {{with seoHeadFor .}}{{.}}{{else}}
     <meta name="description" content="{{settingOr $.Settings "site_description" "Modern company website powered by GoPress."}}">

--- a/themes/modern-company/templates_test.go
+++ b/themes/modern-company/templates_test.go
@@ -1,11 +1,17 @@
 package moderncompany
 
 import (
+	"bytes"
+	"html/template"
+	"strings"
 	"testing"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gin-gonic/gin"
 
 	"go-press/core"
+	"go-press/core/rewrite"
+	coreTheme "go-press/core/theme"
 )
 
 func TestTemplatesCompile(t *testing.T) {
@@ -23,4 +29,60 @@ func TestDemoSeedDoesNotDefineAdmin(t *testing.T) {
 	if data.Admin.Username != "" || data.Admin.Password != "" {
 		t.Fatal("theme demo seed must not define admin credentials")
 	}
+}
+
+func TestBaseTemplateUsesSEOTitleWhenAvailable(t *testing.T) {
+	tmpl := newBaseTemplateTest(t)
+	data := PageData{
+		Title:    "Visible Title",
+		Settings: map[string]string{"site_name": "Hurricane Techs"},
+		SEO:      rewrite.SEOMeta{Title: "Custom SEO Title"},
+	}
+
+	var out bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&out, "base", data); err != nil {
+		t.Fatalf("execute base template: %v", err)
+	}
+	if !strings.Contains(out.String(), "<title>Custom SEO Title</title>") {
+		t.Fatalf("expected SEO title, got: %s", out.String())
+	}
+}
+
+func TestBaseTemplateFallsBackWhenSEOTitleEmpty(t *testing.T) {
+	tmpl := newBaseTemplateTest(t)
+	data := PageData{Title: "Visible Title", Settings: map[string]string{"site_name": "Hurricane Techs"}}
+
+	var out bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&out, "base", data); err != nil {
+		t.Fatalf("execute base template: %v", err)
+	}
+	if !strings.Contains(out.String(), "<title>Visible Title - Hurricane Techs</title>") {
+		t.Fatalf("expected fallback title, got: %s", out.String())
+	}
+}
+
+func newBaseTemplateTest(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl := template.New("base_test").Funcs(template.FuncMap{
+		"currentLang": func(*gin.Context) string { return "en" },
+		"settingOr": func(m map[string]string, key, fallback string) string {
+			if v := m[key]; v != "" {
+				return v
+			}
+			return fallback
+		},
+		"seoHeadFor": func(interface{}) template.HTML { return "" },
+		"pageTitleFor": func(data interface{}, fallback string) string {
+			return coreTheme.CommonFuncMap()["pageTitleFor"].(func(interface{}, string) string)(data, fallback)
+		},
+		"responsiveImagePreload": func(string, string) template.HTML { return "" },
+		"renderHook":             func(string, interface{}) template.HTML { return "" },
+	})
+	if _, err := tmpl.Parse(`{{define "header"}}{{end}}{{define "content"}}{{end}}{{define "footer"}}{{end}}`); err != nil {
+		t.Fatalf("parse template stubs: %v", err)
+	}
+	if _, err := tmpl.ParseFiles("templates/layouts/base.tmpl"); err != nil {
+		t.Fatalf("parse base template: %v", err)
+	}
+	return tmpl
 }

--- a/themes/terra-trail/templates/layouts/base.tmpl
+++ b/themes/terra-trail/templates/layouts/base.tmpl
@@ -6,7 +6,8 @@
     {{if not $hero}}{{$hero = "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1800&h=980&fit=crop&q=84"}}{{end}}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{.Title}} - {{settingOr .Settings "site_name" "TerraTrail"}}</title>
+    {{$fallbackTitle := printf "%s - %s" .Title (settingOr .Settings "site_name" "TerraTrail")}}
+    <title>{{pageTitleFor . $fallbackTitle}}</title>
     {{$siteIcon := settingOr .Settings "site_icon" ""}}
     {{with seoHeadFor .}}{{.}}{{else}}
     <meta name="description" content="{{settingOr $.Settings "site_description" "Curated mountain tours, transport planning, and destination guides for modern travelers."}}">

--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,7 @@ import "fmt"
 const (
 	Major = 0  // Major version component of the current release
 	Minor = 6  // Minor version component of the current release
-	Patch = 3  // Patch version component of the current release
+	Patch = 4  // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
Introduces the `pageTitleFor` function to unify page title generation, prioritizing SEO metadata while providing fallback support. Updates templates across themes to utilize this helper, ensuring consistency and reducing duplication.

Enhances the admin hook bus to include `Ctx` and `HookItem` for improved plugin extensibility. Revises the SEO plugin to align with the updated hook contract, improving metadata handling.

Includes new tests to validate `pageTitleFor` functionality and template integration, ensuring proper fallback behavior and SEO alignment.

Updates documentation to guide theme developers on using `pageTitleFor` for consistent title generation.