### PR TITLE
feat: add SVG sanitization and logo support for themes and plugins

### DIFF
--- a/core/admin/handler.go
+++ b/core/admin/handler.go
@@ -30,9 +30,10 @@ type ThemeDisplayInfo struct {
 	Description  string
 	Author       string
 	Active       bool
-	HasDemoData  bool // theme provides bundled demo seed data
-	DemoImported bool // demo data has already been imported
-	HasSettings  bool // theme provides a settings page
+	HasDemoData  bool          // theme provides bundled demo seed data
+	DemoImported bool          // demo data has already been imported
+	HasSettings  bool          // theme provides a settings page
+	LogoSVG      template.HTML // sanitized inline SVG logo, or "" for none
 }
 
 // ThemeManager provides theme switching callbacks to the admin handler.
@@ -85,6 +86,7 @@ type PluginInfo struct {
 	Description string
 	Active      bool
 	HasSettings bool
+	LogoSVG     template.HTML // sanitized inline SVG logo, or "" for none
 }
 
 // PluginCallbacks provides plugin management callbacks to the admin handler.

--- a/core/admin/locales/en.json
+++ b/core/admin/locales/en.json
@@ -16,6 +16,8 @@
   "action.delete": "Delete",
   "action.edit": "Edit",
   "action.enable_theme": "Enable This Theme",
+  "action.expand_description": "Expand description",
+  "action.collapse_description": "Collapse description",
   "action.force_regenerate_variants": "Force Rebuild Variants",
   "action.filter": "Filter",
   "action.generate_sitemap": "Generate Sitemap",

--- a/core/admin/locales/zh-CN.json
+++ b/core/admin/locales/zh-CN.json
@@ -16,6 +16,8 @@
   "action.delete": "删除",
   "action.edit": "编辑",
   "action.enable_theme": "启用此主题",
+  "action.expand_description": "展开描述",
+  "action.collapse_description": "折叠描述",
   "action.force_regenerate_variants": "强制重建图片变体",
   "action.filter": "筛选",
   "action.generate_sitemap": "生成 Sitemap",

--- a/core/admin/static/css/admin.css
+++ b/core/admin/static/css/admin.css
@@ -262,6 +262,274 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
     padding: 1rem 1.25rem;
 }
 
+/* ==================== Theme / Plugin Cards ==================== */
+.extension-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 370px), 1fr));
+    align-items: start;
+    gap: .85rem;
+}
+.extension-card {
+    display: flex;
+    min-width: 0;
+    min-height: 148px;
+    margin-bottom: 0;
+    flex-direction: column;
+    border: 1px solid #dbe3ed;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, .05), 0 5px 14px rgba(15, 23, 42, .035);
+    transition: border-color .16s ease, box-shadow .16s ease, transform .16s ease;
+}
+.extension-card:hover {
+    border-color: #b8c5d6;
+    box-shadow: 0 2px 4px rgba(15, 23, 42, .07), 0 8px 20px rgba(15, 23, 42, .05);
+    transform: translateY(-1px);
+}
+.extension-card-active {
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 1px rgba(59, 130, 246, .18), 0 5px 16px rgba(37, 99, 235, .08);
+}
+.extension-card-main {
+    display: flex;
+    align-items: flex-start;
+    gap: .8rem;
+    min-width: 0;
+    padding: .9rem .95rem .72rem;
+    flex: 1 1 auto;
+}
+.extension-logo {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 48px;
+    width: 48px;
+    height: 48px;
+    overflow: hidden;
+    border-radius: 8px;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, .12);
+}
+.extension-logo svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+.extension-card-content {
+    min-width: 0;
+    flex: 1 1 auto;
+}
+.extension-card-heading {
+    display: flex;
+    align-items: center;
+    gap: .45rem;
+    min-width: 0;
+}
+.extension-card-heading h3 {
+    min-width: 0;
+    margin: 0;
+    overflow: hidden;
+    color: #172033;
+    font-size: .98rem;
+    line-height: 1.3;
+    font-weight: 700;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.extension-card-badges {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+    min-width: 0;
+    margin-left: auto;
+    flex: 0 0 auto;
+}
+.extension-version {
+    padding: .1rem .38rem;
+    border-radius: 4px;
+    background: #f1f5f9;
+    color: #64748b;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    font-size: .72rem;
+    line-height: 1.35;
+    font-variant-numeric: tabular-nums;
+}
+.extension-card .badge {
+    padding: .12rem .45rem;
+    border-radius: 999px;
+    font-size: .72rem;
+    line-height: 1.35;
+}
+.extension-card .badge-active {
+    border: 1px solid #bbf7d0;
+    background: #dcfce7;
+    color: #15803d;
+}
+.extension-card .badge-inactive {
+    border: 1px solid #e2e8f0;
+    background: #f8fafc;
+    color: #94a3b8;
+}
+.extension-desc-wrap {
+    position: relative;
+    min-width: 0;
+}
+.extension-desc {
+    display: -webkit-box;
+    margin: .34rem 0 0;
+    overflow: hidden;
+    color: #5b6b82;
+    font-size: .86rem;
+    line-height: 1.45;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+.extension-desc-wrap.has-toggle .extension-desc {
+    padding-right: 1.55rem;
+}
+.extension-desc-wrap.is-expanded .extension-desc {
+    display: block;
+    overflow: visible;
+    -webkit-line-clamp: initial;
+}
+.extension-desc-toggle {
+    position: absolute;
+    right: 0;
+    bottom: -1px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: 1px solid #dbe3ed;
+    border-radius: 4px;
+    background: #f8fafc;
+    color: #64748b;
+    cursor: pointer;
+    transition: border-color .15s ease, background-color .15s ease, color .15s ease;
+}
+.extension-desc-toggle[hidden] {
+    display: none;
+}
+.extension-desc-toggle:hover,
+.extension-desc-toggle:focus-visible {
+    border-color: #93c5fd;
+    background: #eff6ff;
+    color: #2563eb;
+    outline: none;
+}
+.extension-desc-toggle svg {
+    width: 14px;
+    height: 14px;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 2;
+    transition: transform .18s ease;
+}
+.extension-desc-toggle[aria-expanded="true"] svg {
+    transform: rotate(180deg);
+}
+.extension-card-footer {
+    display: flex;
+    align-items: center;
+    gap: .65rem;
+    min-width: 0;
+    min-height: 43px;
+    padding: .48rem .95rem;
+    border-top: 1px solid #edf1f5;
+    background: #fbfcfe;
+}
+.extension-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: .42rem;
+    flex: 0 0 auto;
+}
+.extension-actions .inline-form {
+    display: inline-flex;
+}
+.extension-actions .btn {
+    min-height: 28px;
+    padding: .25rem .62rem;
+    font-size: .78rem;
+    white-space: nowrap;
+}
+.extension-meta {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    min-width: 0;
+    margin-left: auto;
+    overflow: hidden;
+    color: #8a9ab1;
+    font-size: .72rem;
+}
+.extension-author {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.extension-author + .extension-slug::before {
+    margin: 0 .45rem;
+    color: #cbd5e1;
+    content: "|";
+}
+.extension-slug {
+    min-width: 0;
+    margin-left: auto;
+    overflow: hidden;
+    color: #91a2ba;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    font-size: .72rem;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.extension-card .btn-settings {
+    border-color: #bfdbfe;
+    background: #fff;
+    color: #2563eb;
+}
+.extension-card .btn-settings:hover {
+    border-color: #2563eb;
+    background: #eff6ff;
+}
+.extension-card .btn-accent {
+    border-color: #86efac;
+    background: #f0fdf4;
+    color: #15803d;
+}
+.extension-card .btn-accent:hover {
+    border-color: #22c55e;
+    background: #dcfce7;
+}
+.extension-card .btn-secondary[disabled] {
+    border-color: #bbf7d0;
+    background: #f0fdf4;
+    color: #16a34a;
+    opacity: 1;
+}
+.demo-check {
+    color: #16a34a;
+    font-weight: 700;
+}
+
+@media (max-width: 720px) {
+    .extension-card-main {
+        padding: .8rem .85rem .65rem;
+    }
+    .extension-card-footer {
+        align-items: flex-start;
+        padding: .52rem .85rem;
+        flex-direction: column;
+    }
+    .extension-meta,
+    .extension-card-footer > .extension-slug {
+        width: 100%;
+        margin-left: 0;
+    }
+}
+
 /* ==================== Stats ==================== */
 .stats-grid {
     display: grid;

--- a/core/admin/static/js/admin.js
+++ b/core/admin/static/js/admin.js
@@ -76,6 +76,46 @@ function adminFormat(template) {
         });
     });
 
+    // Extension cards keep descriptions compact, but expose a disclosure
+    // control whenever the two-line clamp hides content.
+    var extensionDescriptions = document.querySelectorAll('[data-extension-description]');
+    function syncExtensionDescriptionToggles() {
+        extensionDescriptions.forEach(function(wrap) {
+            var desc = wrap.querySelector('.extension-desc');
+            var btn = wrap.querySelector('.extension-desc-toggle');
+            if (!desc || !btn) return;
+            var expanded = btn.getAttribute('aria-expanded') === 'true';
+            if (!expanded) {
+                wrap.classList.remove('has-toggle');
+            }
+            var overflows = desc.scrollHeight > desc.clientHeight + 1;
+            var showToggle = expanded || overflows;
+            btn.hidden = !showToggle;
+            wrap.classList.toggle('has-toggle', showToggle);
+        });
+    }
+    extensionDescriptions.forEach(function(wrap) {
+        var btn = wrap.querySelector('.extension-desc-toggle');
+        if (!btn) return;
+        btn.addEventListener('click', function() {
+            var expanded = btn.getAttribute('aria-expanded') === 'true';
+            var nextExpanded = !expanded;
+            var label = nextExpanded
+                ? btn.getAttribute('data-collapse-label')
+                : btn.getAttribute('data-expand-label');
+            btn.setAttribute('aria-expanded', nextExpanded ? 'true' : 'false');
+            btn.setAttribute('aria-label', label);
+            btn.setAttribute('title', label);
+            wrap.classList.toggle('is-expanded', nextExpanded);
+        });
+    });
+    syncExtensionDescriptionToggles();
+    var extensionDescriptionResizeTimer;
+    window.addEventListener('resize', function() {
+        window.clearTimeout(extensionDescriptionResizeTimer);
+        extensionDescriptionResizeTimer = window.setTimeout(syncExtensionDescriptionToggles, 120);
+    });
+
     // Auto-generate slug from title
     var titleInput = document.getElementById('title');
     var slugInput = document.getElementById('slug');

--- a/core/admin/templates/layouts/admin.tmpl
+++ b/core/admin/templates/layouts/admin.tmpl
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{.Title}} - {{.SiteName}} CMS</title>
-    <link rel="stylesheet" href="/static/admin/css/admin.css?v=43">
+    <link rel="stylesheet" href="/static/admin/css/admin.css?v=50">
 </head>
 <body class="admin-body">
     <aside class="sidebar" id="sidebar">
@@ -136,6 +136,6 @@
         editorVisualModeTitle: {{jsT . "editor.visual_mode_title"}}
     };
     </script>
-    <script src="/static/admin/js/admin.js?v=13"></script>
+    <script src="/static/admin/js/admin.js?v=14"></script>
 </body>
 </html>{{end}}

--- a/core/admin/templates/pages/plugins.tmpl
+++ b/core/admin/templates/pages/plugins.tmpl
@@ -5,141 +5,55 @@
 
 
 
-<div class="plugin-grid">
+<div class="extension-grid plugin-grid">
     {{range .Plugins}}
-    <div class="card plugin-card{{if .Active}} plugin-active{{end}}">
-        <div class="plugin-card-header">
-            <h3>{{.Name}}</h3>
-            <div class="plugin-header-right">
-                <span class="plugin-version">v{{.Version}}</span>
-                {{if .Active}}<span class="badge badge-active">{{T $ "plugin.active"}}</span>{{else}}<span class="badge badge-inactive">{{T $ "plugin.inactive"}}</span>{{end}}
+    <article class="card extension-card plugin-card{{if .Active}} extension-card-active plugin-active{{end}}">
+        <div class="extension-card-main">
+            {{if .LogoSVG}}<span class="extension-logo" aria-hidden="true">{{.LogoSVG}}</span>{{end}}
+            <div class="extension-card-content">
+                <div class="extension-card-heading">
+                    <h3 title="{{.Name}}">{{.Name}}</h3>
+                    <div class="extension-card-badges">
+                        <span class="extension-version">v{{.Version}}</span>
+                        {{if .Active}}<span class="badge badge-active">{{T $ "plugin.active"}}</span>{{else}}<span class="badge badge-inactive">{{T $ "plugin.inactive"}}</span>{{end}}
+                    </div>
+                </div>
+                <div class="extension-desc-wrap" data-extension-description>
+                    <p class="extension-desc" id="plugin-desc-{{.Slug}}">{{.Description}}</p>
+                    <button type="button" class="extension-desc-toggle" hidden
+                            aria-expanded="false" aria-controls="plugin-desc-{{.Slug}}"
+                            aria-label="{{T $ "action.expand_description"}}"
+                            title="{{T $ "action.expand_description"}}"
+                            data-expand-label="{{T $ "action.expand_description"}}"
+                            data-collapse-label="{{T $ "action.collapse_description"}}">
+                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
+                    </button>
+                </div>
             </div>
         </div>
-        <div class="plugin-card-body">
-            <p class="plugin-desc">{{.Description}}</p>
-        </div>
-        <div class="plugin-card-footer">
-            {{if .Active}}
-                {{if .HasSettings}}
-                <a href="/admin/plugins/{{.Slug}}/settings" class="btn btn-sm btn-settings" style="margin-right:0.5rem;">{{T $ "plugin.settings"}}</a>
+        <div class="extension-card-footer">
+            <div class="extension-actions">
+                {{if .Active}}
+                    {{if .HasSettings}}
+                    <a href="/admin/plugins/{{.Slug}}/settings" class="btn btn-sm btn-settings">{{T $ "plugin.settings"}}</a>
+                    {{end}}
+                    <form method="POST" action="/admin/plugins/deactivate" class="inline-form">
+                        <input type="hidden" name="name" value="{{.Name}}">
+                        <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('{{T $ "confirm.deactivate_plugin" .Name}}')">{{T $ "plugin.deactivate"}}</button>
+                    </form>
+                {{else}}
+                    <form method="POST" action="/admin/plugins/activate" class="inline-form">
+                        <input type="hidden" name="name" value="{{.Name}}">
+                        <button type="submit" class="btn btn-sm btn-primary" onclick="return confirm('{{T $ "confirm.activate_plugin" .Name}}')">{{T $ "plugin.activate"}}</button>
+                    </form>
                 {{end}}
-                <form method="POST" action="/admin/plugins/deactivate" class="inline-form" style="display:inline;">
-                    <input type="hidden" name="name" value="{{.Name}}">
-                    <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('{{T $ "confirm.deactivate_plugin" .Name}}')">{{T $ "plugin.deactivate"}}</button>
-                </form>
-            {{else}}
-                <form method="POST" action="/admin/plugins/activate" class="inline-form" style="display:inline;">
-                    <input type="hidden" name="name" value="{{.Name}}">
-                    <button type="submit" class="btn btn-sm btn-primary" onclick="return confirm('{{T $ "confirm.activate_plugin" .Name}}')">{{T $ "plugin.activate"}}</button>
-                </form>
-            {{end}}
+            </div>
+            <span class="extension-slug" title="{{.Slug}}">{{.Slug}}</span>
         </div>
-    </div>
+    </article>
     {{else}}
     <div class="card"><p class="empty-msg">{{T . "plugin.empty"}}</p></div>
     {{end}}
 </div>
 
-<style>
-.plugin-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-    gap: 1.5rem;
-}
-.plugin-card {
-    display: flex;
-    flex-direction: column;
-    border: 2px solid #e2e8f0;
-    transition: border-color 0.2s;
-}
-.plugin-card:hover {
-    border-color: #94a3b8;
-}
-.plugin-active {
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 1px #3b82f6;
-}
-.plugin-card-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem 1.25rem 0.5rem;
-}
-.plugin-card-header h3 {
-    margin: 0;
-    font-size: 1.1rem;
-}
-.plugin-header-right {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-.plugin-version {
-    font-size: 0.8rem;
-    color: #64748b;
-    background: #f1f5f9;
-    padding: 0.15rem 0.5rem;
-    border-radius: 4px;
-}
-.plugin-card-header .badge-active {
-    font-size: 0.75rem;
-    padding: 0.15rem 0.6rem;
-    border-radius: 999px;
-    background: #dcfce7;
-    color: #16a34a;
-    border: 1px solid #bbf7d0;
-}
-.plugin-card-header .badge-inactive {
-    font-size: 0.75rem;
-    padding: 0.15rem 0.6rem;
-    border-radius: 999px;
-    background: #f1f5f9;
-    color: #94a3b8;
-    border: 1px solid #e2e8f0;
-}
-.plugin-card-body {
-    padding: 0.5rem 1.25rem;
-    flex: 1;
-}
-.plugin-desc {
-    color: #475569;
-    font-size: 0.9rem;
-    line-height: 1.5;
-    margin: 0;
-}
-.plugin-card-footer {
-    padding: 0.75rem 1.25rem;
-    border-top: 1px solid #e2e8f0;
-    display: flex;
-    align-items: center;
-}
-.btn-sm {
-    padding: 0.25rem 0.75rem;
-    font-size: 0.8rem;
-}
-.btn-danger {
-    background: #ef4444;
-    color: #fff;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-}
-.btn-danger:hover {
-    background: #dc2626;
-}
-.btn-settings {
-    background: #f8fafc;
-    color: #3b82f6;
-    border: 1px solid #3b82f6;
-    border-radius: 6px;
-    cursor: pointer;
-    text-decoration: none;
-    display: inline-block;
-    line-height: 1.5;
-}
-.btn-settings:hover {
-    background: #3b82f6;
-    color: #fff;
-}
-</style>
 {{end}}

--- a/core/admin/templates/pages/themes.tmpl
+++ b/core/admin/templates/pages/themes.tmpl
@@ -3,175 +3,72 @@
     <h2>{{T . "nav.themes"}}</h2>
 </div>
 
-<div class="theme-grid">
+<div class="extension-grid theme-grid">
     {{range .Themes}}
-    <div class="card theme-card{{if .Active}} theme-active{{end}}">
-        <div class="theme-card-header">
-            <h3>{{.Name}}</h3>
-            <div class="theme-header-right">
-                <span class="theme-version">v{{.Version}}</span>
-                {{if .Active}}<span class="badge badge-active">{{T $ "theme.active"}}</span>{{end}}
+    <article class="card extension-card theme-card{{if .Active}} extension-card-active theme-active{{end}}">
+        <div class="extension-card-main">
+            {{if .LogoSVG}}<span class="extension-logo" aria-hidden="true">{{.LogoSVG}}</span>{{end}}
+            <div class="extension-card-content">
+                <div class="extension-card-heading">
+                    <h3 title="{{.Name}}">{{.Name}}</h3>
+                    <div class="extension-card-badges">
+                        <span class="extension-version">v{{.Version}}</span>
+                        {{if .Active}}<span class="badge badge-active">{{T $ "theme.active"}}</span>{{end}}
+                    </div>
+                </div>
+                <div class="extension-desc-wrap" data-extension-description>
+                    <p class="extension-desc" id="theme-desc-{{.Slug}}">{{.Description}}</p>
+                    <button type="button" class="extension-desc-toggle" hidden
+                            aria-expanded="false" aria-controls="theme-desc-{{.Slug}}"
+                            aria-label="{{T $ "action.expand_description"}}"
+                            title="{{T $ "action.expand_description"}}"
+                            data-expand-label="{{T $ "action.expand_description"}}"
+                            data-collapse-label="{{T $ "action.collapse_description"}}">
+                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
+                    </button>
+                </div>
             </div>
         </div>
-        <div class="theme-card-body">
-            <p class="theme-desc">{{.Description}}</p>
-            <div class="theme-meta">
-                <span><strong>{{T $ "theme.author"}}</strong> {{.Author}}</span>
-                <span><strong>{{T $ "theme.identifier"}}</strong> {{.Slug}}</span>
-            </div>
-        </div>
-        <div class="theme-card-footer">
-            {{if .Active}}
-                {{if .HasSettings}}
-                <a href="/admin/themes/{{.Slug}}/settings" class="btn btn-sm" style="text-decoration:none;">{{T $ "action.theme_settings"}}</a>
-                {{end}}
-                {{if .HasDemoData}}
-                    {{if .DemoImported}}
-                        <button class="btn btn-secondary btn-sm" disabled title="{{T $ "theme.demo_imported"}}">
-                            <span class="demo-check">✓</span> {{T $ "theme.demo_imported"}}
-                        </button>
-                    {{else}}
-                        <form method="POST" action="/admin/themes/demo-import" class="inline-form" style="margin-left:auto;"
-                              data-admin-progress
-                              data-progress-title="{{T $ "progress.demo_import_title"}}"
-                              data-progress-message="{{T $ "progress.demo_import_message"}}">
-                            <input type="hidden" name="theme" value="{{.Slug}}">
-                            <button type="submit" class="btn btn-accent btn-sm"
-                                    onclick="return confirm('{{T $ "confirm.import_demo_data" .Name}}')">
-                                {{T $ "action.import_demo_data"}}
-                            </button>
-                        </form>
+        <div class="extension-card-footer">
+            <div class="extension-actions">
+                {{if .Active}}
+                    {{if .HasSettings}}
+                    <a href="/admin/themes/{{.Slug}}/settings" class="btn btn-sm">{{T $ "action.theme_settings"}}</a>
                     {{end}}
+                    {{if .HasDemoData}}
+                        {{if .DemoImported}}
+                            <button class="btn btn-secondary btn-sm" disabled title="{{T $ "theme.demo_imported"}}">
+                                <span class="demo-check">✓</span> {{T $ "theme.demo_imported"}}
+                            </button>
+                        {{else}}
+                            <form method="POST" action="/admin/themes/demo-import" class="inline-form"
+                                  data-admin-progress
+                                  data-progress-title="{{T $ "progress.demo_import_title"}}"
+                                  data-progress-message="{{T $ "progress.demo_import_message"}}">
+                                <input type="hidden" name="theme" value="{{.Slug}}">
+                                <button type="submit" class="btn btn-accent btn-sm"
+                                        onclick="return confirm('{{T $ "confirm.import_demo_data" .Name}}')">
+                                    {{T $ "action.import_demo_data"}}
+                                </button>
+                            </form>
+                        {{end}}
+                    {{end}}
+                {{else}}
+                    <form method="POST" action="/admin/themes/switch" class="inline-form">
+                        <input type="hidden" name="theme" value="{{.Slug}}">
+                        <button type="submit" class="btn btn-primary btn-sm" onclick="return confirm('{{T $ "confirm.switch_theme" .Name}}')">{{T $ "action.enable_theme"}}</button>
+                    </form>
                 {{end}}
-            {{else}}
-                <form method="POST" action="/admin/themes/switch" class="inline-form">
-                    <input type="hidden" name="theme" value="{{.Slug}}">
-                    <button type="submit" class="btn btn-primary" onclick="return confirm('{{T $ "confirm.switch_theme" .Name}}')">{{T $ "action.enable_theme"}}</button>
-                </form>
-            {{end}}
+            </div>
+            <div class="extension-meta">
+                <span class="extension-author" title="{{T $ "theme.author"}} {{.Author}}">{{.Author}}</span>
+                <span class="extension-slug" title="{{T $ "theme.identifier"}} {{.Slug}}">{{.Slug}}</span>
+            </div>
         </div>
-    </div>
+    </article>
     {{else}}
     <div class="card"><p class="empty-msg">{{T . "theme.empty"}}</p></div>
     {{end}}
 </div>
 
-<style>
-.theme-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-    gap: 1.5rem;
-}
-.theme-card {
-    display: flex;
-    flex-direction: column;
-    border: 2px solid #e2e8f0;
-    transition: border-color 0.2s;
-}
-.theme-card:hover {
-    border-color: #94a3b8;
-}
-.theme-active {
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 1px #3b82f6;
-}
-.theme-card-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem 1.25rem 0.5rem;
-}
-.theme-header-right {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-.theme-card-header h3 {
-    margin: 0;
-    font-size: 1.1rem;
-}
-.theme-version {
-    color: #64748b;
-    font-size: 0.85rem;
-}
-.theme-card-body {
-    padding: 0 1.25rem;
-    flex: 1;
-}
-.theme-desc {
-    color: #475569;
-    font-size: 0.9rem;
-    line-height: 1.5;
-}
-.theme-meta {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    font-size: 0.85rem;
-    color: #64748b;
-    margin-top: 0.5rem;
-}
-.theme-card-footer {
-    padding: 1rem 1.25rem;
-    border-top: 1px solid #e2e8f0;
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-}
-.btn-accent {
-    background: #10b981;
-    color: #fff;
-    border: none;
-    padding: 0.4rem 1rem;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.85rem;
-    transition: background 0.2s;
-}
-.btn-accent:hover {
-    background: #059669;
-}
-.btn-sm {
-    padding: 0.35rem 0.75rem;
-    font-size: 0.82rem;
-}
-.btn-secondary[disabled] {
-    background: #e2e8f0;
-    color: #94a3b8;
-    border: 1px solid #cbd5e1;
-    padding: 0.35rem 0.75rem;
-    border-radius: 6px;
-    font-size: 0.82rem;
-    cursor: not-allowed;
-}
-.demo-check {
-    color: #10b981;
-    font-weight: bold;
-}
-.btn-theme-settings {
-    background: #6366f1;
-    color: #fff;
-    border: none;
-    padding: 0.4rem 1rem;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.85rem;
-    transition: background 0.2s;
-    display: inline-flex;
-    align-items: center;
-}
-.btn-theme-settings:hover {
-    background: #4f46e5;
-    color: #fff;
-}
-.badge-active {
-    background: #dcfce7;
-    color: #16a34a;
-    padding: 0.2rem 0.6rem;
-    border-radius: 999px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    white-space: nowrap;
-}
-</style>
 {{end}}

--- a/core/content/sanitize.go
+++ b/core/content/sanitize.go
@@ -10,6 +10,9 @@ import (
 var (
 	richTextPolicyOnce sync.Once
 	richTextPolicy     *bluemonday.Policy
+
+	svgPolicyOnce sync.Once
+	svgPolicy     *bluemonday.Policy
 )
 
 // SanitizeHTML removes executable or otherwise unsafe markup while preserving
@@ -22,6 +25,41 @@ func SanitizeHTML(value string) string {
 		richTextPolicy = bluemonday.UGCPolicy()
 	})
 	return richTextPolicy.Sanitize(value)
+}
+
+// SanitizeSVG returns an inline-safe copy of an SVG document: all scripting
+// elements and event-handler attributes are stripped, leaving only static
+// drawing primitives. It is used before inlining theme/plugin logo assets into
+// admin pages, so a (possibly third-party) extension cannot smuggle script into
+// the admin origin through its logo.svg. Returns "" for blank input.
+func SanitizeSVG(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	svgPolicyOnce.Do(func() {
+		p := bluemonday.NewPolicy()
+		p.AllowElements(
+			"svg", "g", "path", "circle", "rect", "line", "polyline", "polygon",
+			"ellipse", "defs", "title", "desc", "clipPath",
+		)
+		p.AllowAttrs(
+			"viewBox", "preserveAspectRatio", "xmlns", "width", "height", "fill",
+			"stroke", "stroke-width", "stroke-linecap", "stroke-linejoin",
+			"stroke-miterlimit", "stroke-dasharray", "d", "cx", "cy", "r", "rx", "ry",
+			"x", "y", "x1", "y1", "x2", "y2", "points", "transform", "fill-rule",
+			"clip-rule", "fill-opacity", "stroke-opacity", "opacity", "clip-path",
+			"id", "class", "role", "aria-hidden", "focusable",
+		).Globally()
+		svgPolicy = p
+	})
+	out := svgPolicy.Sanitize(value)
+	// bluemonday lowercases attribute names, but SVG attribute names are
+	// case-sensitive: a lowercased "viewbox" is ignored by the renderer and the
+	// icon loses its coordinate system. Restore the camelCase attributes our
+	// policy allows.
+	out = strings.ReplaceAll(out, " viewbox=", " viewBox=")
+	out = strings.ReplaceAll(out, " preserveaspectratio=", " preserveAspectRatio=")
+	return out
 }
 
 func sanitizeContent(item *Content) {

--- a/core/content/sanitize_svg_test.go
+++ b/core/content/sanitize_svg_test.go
@@ -1,0 +1,66 @@
+package content
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeSVGStripsScripting(t *testing.T) {
+	in := `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">` +
+		`<script>alert(1)</script>` +
+		`<circle cx="24" cy="24" r="10" onload="steal()" fill="#fff"/>` +
+		`<a href="javascript:evil()"><rect width="10" height="10"/></a>` +
+		`</svg>`
+	out := SanitizeSVG(in)
+	for _, bad := range []string{"script", "alert", "onload", "javascript:", "<a"} {
+		if strings.Contains(out, bad) {
+			t.Errorf("sanitized SVG still contains %q: %s", bad, out)
+		}
+	}
+	if !strings.Contains(out, "<circle") {
+		t.Errorf("sanitized SVG dropped the circle shape: %s", out)
+	}
+}
+
+func TestSanitizeSVGPreservesViewBoxCase(t *testing.T) {
+	out := SanitizeSVG(`<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><rect width="48" height="48" rx="11" fill="#4f46e5"/></svg>`)
+	if !strings.Contains(out, "viewBox=") {
+		t.Fatalf("viewBox case was not preserved: %s", out)
+	}
+	if strings.Contains(out, "viewbox=") {
+		t.Fatalf("lowercase viewbox leaked into output: %s", out)
+	}
+}
+
+func TestSanitizeSVGEmpty(t *testing.T) {
+	if got := SanitizeSVG("   "); got != "" {
+		t.Fatalf("SanitizeSVG(blank) = %q, want empty", got)
+	}
+}
+
+// The bundled theme and plugin logos must survive sanitization intact (viewBox
+// preserved, shapes kept) so the admin cards render them.
+func TestBundledLogosSurviveSanitization(t *testing.T) {
+	root := filepath.Join("..", "..")
+	dirs := []string{
+		"themes/modern-company", "themes/atelier-slate", "themes/atelier-slate-gp",
+		"themes/axis-form", "themes/bitcuz-mag", "themes/civic-estate",
+		"themes/financial-news", "themes/florafi", "themes/go-press-landing",
+		"themes/terra-trail",
+		"plugins/code-snippets", "plugins/gopress-analytics", "plugins/multilang",
+		"plugins/seo-extras", "plugins/google-identity", "plugins/metamask-identity",
+	}
+	for _, d := range dirs {
+		raw, err := os.ReadFile(filepath.Join(root, d, "static", "logo.svg"))
+		if err != nil {
+			t.Errorf("%s: missing logo.svg: %v", d, err)
+			continue
+		}
+		out := SanitizeSVG(string(raw))
+		if !strings.Contains(out, "<svg") || !strings.Contains(out, "viewBox=") {
+			t.Errorf("%s: logo did not survive sanitization: %s", d, out)
+		}
+	}
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"html/template"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -51,6 +52,9 @@ type ThemeInfo struct {
 	Description string
 	Author      string
 	Active      bool
+	// LogoSVG is the theme's sanitized inline SVG logo, or "" when the theme
+	// provides no static/logo.svg. Safe to inline into admin pages.
+	LogoSVG string
 }
 
 // Engine is the main GoPress application container.
@@ -400,9 +404,22 @@ func (e *Engine) AvailableThemes() []ThemeInfo {
 			Description: t.Description(),
 			Author:      t.Author(),
 			Active:      slug == active,
+			LogoSVG:     extensionLogoSVG(t),
 		})
 	}
 	return infos
+}
+
+// extensionLogoSVG extracts and sanitizes the inline SVG logo from a theme or
+// plugin that implements LogoSVG() string (theme.LogoProvider / plugin.LogoProvider).
+// Returns "" when the extension provides no logo. The result is sanitized so it
+// is safe to inline into admin pages, even for third-party extensions.
+func extensionLogoSVG(x interface{}) string {
+	lp, ok := x.(interface{ LogoSVG() string })
+	if !ok {
+		return ""
+	}
+	return content.SanitizeSVG(lp.LogoSVG())
 }
 
 // ThemeDemoSeedPath returns the seed.toml path for the given theme slug,
@@ -787,6 +804,7 @@ func (e *Engine) SetupAdmin() {
 					HasDemoData:  e.ThemeDemoSeedPath(t.Slug) != "",
 					DemoImported: e.IsThemeDemoImported(t.Slug),
 					HasSettings:  e.ThemeSettingsTemplatePath(t.Slug) != "",
+					LogoSVG:      template.HTML(t.LogoSVG),
 				}
 			}
 			return result
@@ -860,6 +878,7 @@ func (e *Engine) SetupAdmin() {
 					Description: p.Description(),
 					Active:      e.PluginManager.IsActive(p.Name()),
 					HasSettings: hasSettings,
+					LogoSVG:     template.HTML(extensionLogoSVG(p)),
 				}
 			}
 			return result

--- a/core/plugin/plugin.go
+++ b/core/plugin/plugin.go
@@ -55,6 +55,13 @@ type SettingsSaveProvider interface {
 	OnSettingsSave(settings map[string]string)
 }
 
+// LogoProvider is an optional interface that plugins can implement to supply an
+// inline SVG logo shown on the admin plugin card. Return "" for no logo. Core
+// sanitizes the markup before rendering it into admin pages.
+type LogoProvider interface {
+	LogoSVG() string
+}
+
 // Slug returns the stable admin/settings identifier for a plugin.
 //
 // Plugin names are already expected to be URL-safe slugs such as

--- a/core/theme/base.go
+++ b/core/theme/base.go
@@ -5,6 +5,8 @@ import (
 	"html/template"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -67,6 +69,22 @@ func (b *BaseTheme) InitBase(app App, themeDir string, extraFuncs template.FuncM
 	b.PageTemplates = make(map[string]*template.Template)
 	b.CustomRoutes = make(map[string]map[string]gin.HandlerFunc)
 	b.customFuncMap = extraFuncs
+}
+
+// LogoSVG implements the optional LogoProvider interface: it returns the raw SVG
+// markup from static/logo.svg in the theme directory, or "" when absent. Every
+// theme embedding BaseTheme gets this for free — dropping a static/logo.svg file
+// is enough to show a logo on the admin theme card. Core sanitizes the markup
+// before rendering it.
+func (b *BaseTheme) LogoSVG() string {
+	if b == nil || b.ThemeDir == "" {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(b.ThemeDir, "static", "logo.svg"))
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }
 
 // AddRoute registers a custom theme route such as /about or /contact.

--- a/core/theme/theme.go
+++ b/core/theme/theme.go
@@ -115,6 +115,16 @@ type SettingsProvider interface {
 	SettingsTemplatePath() string
 }
 
+// LogoProvider is an optional interface that themes can implement to supply an
+// inline SVG logo shown on the admin theme card. BaseTheme provides a default
+// implementation that reads static/logo.svg from the theme directory, so most
+// themes only need to drop that file in — no Go code required.
+type LogoProvider interface {
+	// LogoSVG returns the raw SVG markup for the theme logo, or "" if none.
+	// Core sanitizes the markup before rendering it into admin pages.
+	LogoSVG() string
+}
+
 // Config holds the [theme] metadata parsed from theme.toml.
 type Config struct {
 	Name        string `toml:"name"`

--- a/docs/guide/en/plugins/creating-plugins.md
+++ b/docs/guide/en/plugins/creating-plugins.md
@@ -80,6 +80,19 @@ Plugins that need admin configuration should implement the settings provider int
 
 Keep settings templates translated through locale files instead of hard-coded strings.
 
+## Admin Card Logo
+
+Implement the optional `LogoProvider` to show an icon on the admin **Plugins** card. Embed a square `static/logo.svg` (`viewBox="0 0 48 48"`) and return it:
+
+```go
+//go:embed static/logo.svg
+var logoSVG string
+
+func (p *Plugin) LogoSVG() string { return logoSVG }
+```
+
+Core runs `content.SanitizeSVG` (stripping `<script>`, `on*` handlers, `javascript:` URIs) before inlining, so third-party plugin logos are safe; return `""` for no icon.
+
 ## Frontend Output
 
 Use standard theme hook slots:

--- a/docs/guide/en/themes/creating-themes.md
+++ b/docs/guide/en/themes/creating-themes.md
@@ -218,3 +218,12 @@ func (t *MyTheme) DemoSeedPath() string {
     return filepath.Join(t.ThemeDir, "demo", "data", "seed.toml")
 }
 ```
+
+## Admin Card Logo
+
+The admin **Themes** page shows an icon next to each theme name. The convention is minimal: **just drop a `static/logo.svg`** — `BaseTheme` implements the optional `LogoProvider.LogoSVG()` and reads that file automatically, so no Go code is required.
+
+- Use a square icon with `viewBox="0 0 48 48"` (the card renders it at ~34px).
+- Core runs `content.SanitizeSVG` (stripping `<script>`, `on*` handlers, `javascript:` URIs, …) before inlining, so even a third-party theme's logo cannot smuggle script into the admin origin.
+- With no such file, the card simply shows no icon.
+- To generate the logo dynamically, override `LogoSVG() string` on the theme.

--- a/docs/guide/en/themes/overview.md
+++ b/docs/guide/en/themes/overview.md
@@ -14,6 +14,7 @@ GoPress themes are Go packages that register themselves with the engine. A theme
 - Site-timezone-aware `formatDate` and `formatDateTime` helpers from `BaseFuncMap`.
 - Responsive image helpers backed by media variants.
 - Demo data import through `DemoDataProvider`.
+- Admin theme-card logo through `LogoProvider` — drop a `static/logo.svg`; `BaseTheme` reads it automatically (no Go code) and core sanitizes it before inlining.
 
 ## Built-in Themes
 

--- a/docs/guide/zh-CN/plugins/creating-plugins.md
+++ b/docs/guide/zh-CN/plugins/creating-plugins.md
@@ -99,7 +99,16 @@ func (p *MyPlugin) SettingsData() map[string]interface{} {
 func (p *MyPlugin) OnSettingsSave(settings map[string]string) {
     // 同步设置到插件自有表...
 }
+
+// LogoProvider — 在后台「插件管理」卡片上显示插件图标
+//
+//go:embed static/logo.svg
+var logoSVG string
+
+func (p *MyPlugin) LogoSVG() string { return logoSVG }
 ```
+
+`LogoProvider` 与主题一致：把一个 `viewBox="0 0 48 48"` 的方形 SVG 嵌入插件（`//go:embed`），`LogoSVG()` 返回其内容即可。core 会先用 `content.SanitizeSVG` 清洗再内联进后台，所以第三方插件的 logo 也安全；返回 `""` 则卡片不显示图标。
 
 ## 注册请求级内容过滤（Content Scope API）
 

--- a/docs/guide/zh-CN/themes/creating-themes.md
+++ b/docs/guide/zh-CN/themes/creating-themes.md
@@ -252,6 +252,7 @@ themes/my-theme/
 │   └── zh.json
 ├── demo/data/seed.toml       # 内置演示数据（可选）
 ├── static/
+│   ├── logo.svg              # 后台主题卡片图标（可选，见下文）
 │   ├── css/style.css
 │   └── js/main.js
 └── templates/
@@ -268,6 +269,15 @@ func (t *MyTheme) DemoSeedPath() string {
     return filepath.Join(t.ThemeDir, "demo", "data", "seed.toml")
 }
 ```
+
+## 后台卡片 Logo
+
+后台「主题管理」的卡片会在标题旁显示主题图标。约定极简：**在 `static/logo.svg` 放一个 SVG 即可**——`BaseTheme` 已实现可选接口 `LogoProvider.LogoSVG()`，会自动读取该文件，**无需写任何 Go 代码**。
+
+- 建议用 `viewBox="0 0 48 48"` 的方形图标（卡片按约 34px 显示）。
+- core 会先用 `content.SanitizeSVG` 清洗（剥离 `<script>` / `on*` 事件 / `javascript:` 等）再内联进后台页面，所以即使第三方主题的 logo 也不会把脚本带进后台 origin。
+- 没有该文件时卡片不显示图标，行为不变。
+- 如需动态生成 logo，可在主题上自行覆盖 `LogoSVG() string` 方法。
 
 ## 主题设置页
 

--- a/docs/guide/zh-CN/themes/overview.md
+++ b/docs/guide/zh-CN/themes/overview.md
@@ -19,6 +19,7 @@ GoPress 的主题系统借鉴 WordPress 设计：主题是一个 Go 包，通过
 - **SEO 自动注入** — 每个页面模板自动获得 `SEO` 数据（title、OG、JSON-LD），详见 [SEO 接入规范](seo-integration.md)
 - **热切换** — 后台一键切换主题，自动重建路由 + 刷新缓存
 - **DemoDataProvider** — 主题可实现 `DemoSeedPath()` 接口，后台一键导入演示内容和图片
+- **LogoProvider（后台卡片 Logo）** — 主题在 `static/logo.svg` 放一个 SVG，后台「主题管理」卡片即显示图标；`BaseTheme` 自动读取该文件（无需写 Go 代码），core 消毒后内联，第三方主题也安全
 - **init() 自注册** — 主题通过 `init()` 函数自动注册到引擎
 - **零主题/插件交叉耦合** — 主题只依赖 core funcmap 的字符串 key（`{{T .Ctx "x"}}`、`{{langPrefixURL .Ctx "/blog"}}`、`{{renderHook "theme.head.end" .}}`），插件只向 core 注册 hook/ctx key。**主题和插件之间不存在任何直接调用或类型依赖**
 

--- a/plugins/code-snippets/logo.go
+++ b/plugins/code-snippets/logo.go
@@ -1,0 +1,10 @@
+package codesnippets
+
+import _ "embed"
+
+//go:embed static/logo.svg
+var adminCardLogoSVG string
+
+// LogoSVG implements plugin.LogoProvider: the inline SVG shown on the admin
+// plugin card. Core sanitizes the markup before rendering it.
+func (p *Plugin) LogoSVG() string { return adminCardLogoSVG }

--- a/plugins/code-snippets/static/logo.svg
+++ b/plugins/code-snippets/static/logo.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <rect width="48" height="48" rx="11" fill="#0f172a"/>
+  <path d="M20 19l-6 5 6 5" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M28 19l6 5-6 5" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M26 16l-4 16" stroke="#38bdf8" stroke-width="2.4" stroke-linecap="round"/>
+</svg>

--- a/plugins/google-identity/logo.go
+++ b/plugins/google-identity/logo.go
@@ -1,0 +1,10 @@
+package googleidentity
+
+import _ "embed"
+
+//go:embed static/logo.svg
+var adminCardLogoSVG string
+
+// LogoSVG implements plugin.LogoProvider: the inline SVG shown on the admin
+// plugin card. Core sanitizes the markup before rendering it.
+func (p *Plugin) LogoSVG() string { return adminCardLogoSVG }

--- a/plugins/google-identity/static/logo.svg
+++ b/plugins/google-identity/static/logo.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <rect width="48" height="48" rx="11" fill="#2563eb"/>
+  <path d="M24 13l9 4v6c0 6-4 10.5-9 12.5-5-2-9-6.5-9-12.5v-6z" fill="none" stroke="#fff" stroke-width="2.2" stroke-linejoin="round"/>
+  <path d="M20 24l3 3 6-6" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/plugins/gopress-analytics/logo.go
+++ b/plugins/gopress-analytics/logo.go
@@ -1,0 +1,10 @@
+package gopressanalytics
+
+import _ "embed"
+
+//go:embed static/logo.svg
+var adminCardLogoSVG string
+
+// LogoSVG implements plugin.LogoProvider: the inline SVG shown on the admin
+// plugin card. Core sanitizes the markup before rendering it.
+func (p *Plugin) LogoSVG() string { return adminCardLogoSVG }

--- a/plugins/gopress-analytics/static/logo.svg
+++ b/plugins/gopress-analytics/static/logo.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <rect width="48" height="48" rx="11" fill="#0891b2"/>
+  <path d="M15 33h18" stroke="#fff" stroke-width="2.2" stroke-linecap="round"/>
+  <rect x="17" y="24" width="4" height="7" rx="1" fill="#fff"/>
+  <rect x="23" y="19" width="4" height="12" rx="1" fill="#fff"/>
+  <rect x="29" y="15" width="4" height="16" rx="1" fill="#fff"/>
+</svg>

--- a/plugins/gopress-analytics/templates/admin/dashboard_widget.tmpl
+++ b/plugins/gopress-analytics/templates/admin/dashboard_widget.tmpl
@@ -91,14 +91,14 @@
 .gpa-donut-card { flex:1 1 0; min-height:0; display:flex; flex-direction:column; border-bottom:1px solid var(--border); padding-bottom:.75rem; }
 .gpa-donut-card:last-child { border-bottom:0; padding-bottom:0; }
 .gpa-donut-card .gpa-panel-title { margin-bottom:.4rem; }
-.gpa-donut-wrap { flex:1; display:grid; grid-template-columns:86px minmax(0,1fr); gap:.85rem; align-items:center; min-height:0; }
-.gpa-donut { width:78px; height:78px; border-radius:50%; display:grid; place-items:center; background:conic-gradient(#2563eb 0deg,#e2e8f0 0deg); position:relative; }
-.gpa-donut::after { content:""; position:absolute; inset:18px; border-radius:50%; background:#fff; }
+.gpa-donut-wrap { flex:1; display:grid; grid-template-columns:108px minmax(0,1fr); gap:.55rem; align-items:center; min-height:0; }
+.gpa-donut { width:100px; height:100px; border-radius:50%; display:grid; place-items:center; background:conic-gradient(#2563eb 0deg,#e2e8f0 0deg); position:relative; }
+.gpa-donut::after { content:""; position:absolute; inset:24px; border-radius:50%; background:#fff; }
 .gpa-donut span { position:relative; z-index:1; color:#0f172a; font-size:1rem; font-weight:750; }
 .gpa-donut-legend { display:grid; gap:.55rem; min-width:0; }
-.gpa-donut-legend div { display:grid; grid-template-columns:auto minmax(0,1fr) auto; gap:.45rem; align-items:center; color:#475569; font-size:.76rem; }
-.gpa-donut-legend span { overflow:hidden; white-space:nowrap; text-overflow:ellipsis; }
-.gpa-donut-legend strong { color:#0f172a; }
+.gpa-donut-legend div { display:flex; gap:.45rem; align-items:center; min-width:0; color:#475569; font-size:.76rem; }
+.gpa-donut-legend span { flex:0 1 auto; min-width:0; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; }
+.gpa-donut-legend strong { flex:0 0 auto; min-width:54px; color:#0f172a; text-align:right; font-variant-numeric:tabular-nums; }
 .gpa-dot { width:9px; height:9px; border-radius:50%; display:inline-block; }
 .gpa-dot-primary { background:#2563eb; }
 .gpa-dot-soft { background:#93c5fd; }

--- a/plugins/metamask-identity/logo.go
+++ b/plugins/metamask-identity/logo.go
@@ -1,0 +1,12 @@
+package metamaskidentity
+
+// LogoSVG implements plugin.LogoProvider: the inline SVG shown on the admin
+// plugin card, read from the already-embedded static assets. Core sanitizes the
+// markup before rendering it.
+func (p *Plugin) LogoSVG() string {
+	data, err := publicFiles.ReadFile("static/logo.svg")
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}

--- a/plugins/metamask-identity/static/logo.svg
+++ b/plugins/metamask-identity/static/logo.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <rect width="48" height="48" rx="11" fill="#e2761b"/>
+  <path d="M15 15l6.5 4h5L33 15l-2 8.5 3 3-2 6-5.5-2h-5L16 32.5l-2-6 3-3z" fill="none" stroke="#fff" stroke-width="2" stroke-linejoin="round"/>
+  <circle cx="20.5" cy="24.5" r="1.5" fill="#fff"/>
+  <circle cx="27.5" cy="24.5" r="1.5" fill="#fff"/>
+  <path d="M21 28.5l1.5 1.5h3l1.5-1.5" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/plugins/multilang/logo.go
+++ b/plugins/multilang/logo.go
@@ -1,0 +1,10 @@
+package multilang
+
+import _ "embed"
+
+//go:embed static/logo.svg
+var adminCardLogoSVG string
+
+// LogoSVG implements plugin.LogoProvider: the inline SVG shown on the admin
+// plugin card. Core sanitizes the markup before rendering it.
+func (p *Plugin) LogoSVG() string { return adminCardLogoSVG }

--- a/plugins/multilang/static/logo.svg
+++ b/plugins/multilang/static/logo.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <rect width="48" height="48" rx="11" fill="#7c3aed"/>
+  <circle cx="24" cy="24" r="10.5" fill="none" stroke="#fff" stroke-width="2.2"/>
+  <path d="M13.5 24h21M24 13.5c3.2 3 3.2 18 0 21M24 13.5c-3.2 3-3.2 18 0 21" fill="none" stroke="#fff" stroke-width="1.8"/>
+</svg>

--- a/plugins/seo-extras/logo.go
+++ b/plugins/seo-extras/logo.go
@@ -1,0 +1,10 @@
+package seoextras
+
+import _ "embed"
+
+//go:embed static/logo.svg
+var adminCardLogoSVG string
+
+// LogoSVG implements plugin.LogoProvider: the inline SVG shown on the admin
+// plugin card. Core sanitizes the markup before rendering it.
+func (p *Plugin) LogoSVG() string { return adminCardLogoSVG }

--- a/plugins/seo-extras/static/logo.svg
+++ b/plugins/seo-extras/static/logo.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <rect width="48" height="48" rx="11" fill="#059669"/>
+  <circle cx="22" cy="22" r="7" fill="none" stroke="#fff" stroke-width="2.4"/>
+  <path d="M27 27l6 6" stroke="#fff" stroke-width="2.6" stroke-linecap="round"/>
+  <path d="M19 24l2-3 2 2 3-4" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/themes/atelier-slate/static/logo.svg
+++ b/themes/atelier-slate/static/logo.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <rect width="48" height="48" rx="11" fill="#334155"/>
+  <rect x="13" y="18" width="16" height="16" rx="3" fill="none" stroke="#fff" stroke-width="2.2"/>
+  <rect x="19" y="14" width="16" height="16" rx="3" fill="#334155" stroke="#fff" stroke-width="2.2"/>
+  <circle cx="24.5" cy="19.5" r="1.8" fill="#fff"/>
+  <path d="M20 28l4-4 3 3 3-3 2 2" fill="none" stroke="#fff" stroke-width="2.2" stroke-linejoin="round" stroke-linecap="round"/>
+</svg>

--- a/themes/axis-form/static/logo.svg
+++ b/themes/axis-form/static/logo.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <rect width="48" height="48" rx="11" fill="#1e293b"/>
+  <path d="M16 13v19h19" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M16 23h7v9M23 23h9" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" opacity="0.85"/>
+  <circle cx="16" cy="13" r="2.3" fill="#fff"/>
+  <circle cx="23" cy="23" r="2" fill="#fff"/>
+  <circle cx="35" cy="32" r="2.3" fill="#fff"/>
+</svg>

--- a/themes/civic-estate/static/logo.svg
+++ b/themes/civic-estate/static/logo.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <rect width="48" height="48" rx="11" fill="#0d9488"/>
+  <path d="M13 24l11-9 11 9" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M16 22v12h16V22" fill="none" stroke="#fff" stroke-width="2.4" stroke-linejoin="round"/>
+  <path d="M21 34v-7h6v7" fill="none" stroke="#fff" stroke-width="2.2" stroke-linejoin="round"/>
+</svg>

--- a/themes/financial-news/static/logo.svg
+++ b/themes/financial-news/static/logo.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <rect width="48" height="48" rx="11" fill="#1d4ed8"/>
+  <path d="M14 32l6-6 4 3 8-9" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M29 14h6v6" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M14 35h21" stroke="#fff" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+</svg>

--- a/themes/florafi/static/logo.svg
+++ b/themes/florafi/static/logo.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <rect width="48" height="48" rx="11" fill="#16a34a"/>
+  <path d="M16 32c0-8 6-15 15-15 0 8-6 15-15 15z" fill="none" stroke="#fff" stroke-width="2.2" stroke-linejoin="round"/>
+  <path d="M16 32c3-5 7-8 11-10" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round"/>
+  <circle cx="30" cy="31" r="4.5" fill="#16a34a" stroke="#fff" stroke-width="2.2"/>
+  <path d="M30 29v4M28.5 31h3" stroke="#fff" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/themes/go-press-landing/static/logo.svg
+++ b/themes/go-press-landing/static/logo.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <rect width="48" height="48" rx="11" fill="#7c3aed"/>
+  <path d="M24 13c5 3 7 8 7 14l-3 3h-8l-3-3c0-6 2-11 7-14z" fill="none" stroke="#fff" stroke-width="2.2" stroke-linejoin="round"/>
+  <circle cx="24" cy="23" r="2.4" fill="#fff"/>
+  <path d="M20 32l-2 4M28 32l2 4M24 33v4" stroke="#fff" stroke-width="2.2" stroke-linecap="round"/>
+</svg>

--- a/themes/modern-company/static/logo.svg
+++ b/themes/modern-company/static/logo.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <rect width="48" height="48" rx="11" fill="#4f46e5"/>
+  <path d="M14 35V15a1 1 0 0 1 1-1h11a1 1 0 0 1 1 1v20" fill="none" stroke="#fff" stroke-width="2.2" stroke-linejoin="round"/>
+  <path d="M27 22h6a1 1 0 0 1 1 1v12" fill="none" stroke="#fff" stroke-width="2.2" stroke-linejoin="round"/>
+  <path d="M18 19v0M23 19v0M18 24v0M23 24v0M18 29v0M23 29v0M30 27v0M30 31v0" stroke="#fff" stroke-width="2.6" stroke-linecap="round"/>
+  <path d="M11 35h26" stroke="#fff" stroke-width="2.4" stroke-linecap="round"/>
+</svg>

--- a/themes/terra-trail/static/logo.svg
+++ b/themes/terra-trail/static/logo.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+  <rect width="48" height="48" rx="11" fill="#b45309"/>
+  <path d="M12 33l8-13 5 7 3-4 8 10z" fill="none" stroke="#fff" stroke-width="2.2" stroke-linejoin="round"/>
+  <circle cx="31" cy="17" r="2.6" fill="#fff"/>
+  <path d="M16 33c2-3 5-2 6-4s4-2 6 0" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-dasharray="1 3.5"/>
+</svg>

--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,7 @@ import "fmt"
 const (
 	Major = 0  // Major version component of the current release
 	Minor = 6  // Minor version component of the current release
-	Patch = 18 // Patch version component of the current release
+	Patch = 19 // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
- Implemented SanitizeSVG function to strip unsafe elements from SVGs, ensuring safe inlining in admin pages.
- Added LogoProvider interface for plugins and themes to provide inline SVG logos.
- Updated BaseTheme to automatically read static/logo.svg for theme logos.
- Enhanced the admin interface to display sanitized logos for both themes and plugins.
- Created tests for SVG sanitization and ensured bundled logos survive sanitization.
- Added logo support to existing plugins and themes, including logo SVG files.
- Bumped version to 0.6.19.